### PR TITLE
Winbuild private spdlog

### DIFF
--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -172,6 +172,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      
+      # The pthreads-win32 build depends on the VS2010 runtime - which isn't on the latest runners
       -
         name: install-VS2010-redistributable
         run: |
@@ -182,7 +184,7 @@ jobs:
         shell: cmd
         run: |
           python --version
-          python -m pip install --upgrade setuptools six
+          python -m pip install --upgrade six
           mkdir build && cd build
           cmake -DCMAKE_INSTALL_PREFIX=gravity  -G"Visual Studio 17 2022" -A x64 ..
           cmake --build . --target install --config Release --parallel

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -12,8 +12,8 @@ jobs:
     container:
       image: ghcr.io/aphysci/gravity_base:bionic
       credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
+            username: ${{ github.actor }}
+            password: ${{ secrets.GHCR_TOKEN }}
       volumes:
         - /node20217:/node20217:rw,rshared
         - /node20217:/__e/node20:ro,rshared

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -178,7 +178,7 @@ jobs:
         name: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.7.9'
+          python-version: '3.11'
 
       # The pthreads-win32 build depends on the VS2010 runtime - which isn't on the latest runners
       -

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -9,13 +9,11 @@ on:
 jobs:
   build-bionic:
     runs-on: ubuntu-latest
-    permissions:
-      packages: read
     container:
       image: ghcr.io/aphysci/gravity_base:bionic
       credentials:
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.PAT }}
       volumes:
         - /node20217:/node20217:rw,rshared
         - /node20217:/__e/node20:ro,rshared

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -13,7 +13,7 @@ jobs:
       image: ghcr.io/aphysci/gravity_base:bionic
       credentials:
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.github_token }}
       volumes:
         - /node20217:/node20217:rw,rshared
         - /node20217:/__e/node20:ro,rshared

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -178,7 +178,7 @@ jobs:
         name: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.9'
 
       # The pthreads-win32 build depends on the VS2010 runtime - which isn't on the latest runners
       -

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -13,7 +13,7 @@ jobs:
       image: ghcr.io/aphysci/gravity_base:bionic
       credentials:
         username: ${{ github.actor }}
-        password: ${{ secrets.PAT }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       volumes:
         - /node20217:/node20217:rw,rshared
         - /node20217:/__e/node20:ro,rshared

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -11,9 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/aphysci/gravity_base:bionic
-      credentials:
-            username: ${{ github.actor }}
-            password: ${{ secrets.GHCR_TOKEN }}
       volumes:
         - /node20217:/node20217:rw,rshared
         - /node20217:/__e/node20:ro,rshared

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -178,7 +178,7 @@ jobs:
         name: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.8'
 
       # The pthreads-win32 build depends on the VS2010 runtime - which isn't on the latest runners
       -

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -172,12 +172,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      # Use a set working python version and VS-2019 as newer versions can't seem to load _gravity.pyd on Windows
-      - 
-        name: setup-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.7.9'
       -
         name: install-VS2010-redistributable
         run: |

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -9,11 +9,13 @@ on:
 jobs:
   build-bionic:
     runs-on: ubuntu-latest
+    permissions:
+      packages: read
     container:
       image: ghcr.io/aphysci/gravity_base:bionic
       credentials:
         username: ${{ github.actor }}
-        password: ${{ secrets.PAT }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       volumes:
         - /node20217:/node20217:rw,rshared
         - /node20217:/__e/node20:ro,rshared

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -163,8 +163,8 @@ jobs:
         with:
           files: ${{ github.workspace }}/build/output/*.tar.gz
 
-  build-windows-2019:
-    runs-on: windows-2019
+  build-windows-latest:
+    runs-on: windows-latest
     timeout-minutes: 60
     steps:
       - 
@@ -178,6 +178,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.7.9'
+      -
+        name: install-VS2010-redistributable
+        run: |
+          Invoke-WebRequest "https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x64.exe" -OutFile vcredist2010_x64.exe
+          .\vcredist2010_x64.exe /quiet /norestart
       - 
         name: build
         shell: cmd
@@ -185,7 +190,7 @@ jobs:
           python --version
           python -m pip install --upgrade setuptools six
           mkdir build && cd build
-          cmake -DCMAKE_INSTALL_PREFIX=gravity  -G"Visual Studio 16 2019" -A x64 ..
+          cmake -DCMAKE_INSTALL_PREFIX=gravity  -G"Visual Studio 17 2022" -A x64 ..
           cmake --build . --target install --config Release --parallel
           start /B gravity/bin/ServiceDirectory.exe
           ctest --test-dir gravity_external_examples_tests-prefix/src/gravity_external_examples_tests-build -C Release --verbose

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/aphysci/gravity_base:bionic
+      credentials:
+            username: ${{ github.actor }}
+            password: ${{ secrets.GHCR_TOKEN }}
       volumes:
         - /node20217:/node20217:rw,rshared
         - /node20217:/__e/node20:ro,rshared

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -178,7 +178,7 @@ jobs:
         name: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.10'
 
       # The pthreads-win32 build depends on the VS2010 runtime - which isn't on the latest runners
       -

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -172,13 +172,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      
-      # Use a set working python version as newer versions can't seem to load _gravity.pyd on Windows
       - 
         name: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.7.9'
+          python-version: '3.11'
 
       # The pthreads-win32 build depends on the VS2010 runtime - which isn't on the latest runners
       -

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -173,12 +173,12 @@ jobs:
         with:
           fetch-depth: 0
       
-      # Use a set working python version compatible with the older version of protobuf pulled in
+      # Use a set working python version as newer versions can't seem to load _gravity.pyd on Windows
       - 
         name: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.7.9'
 
       # The pthreads-win32 build depends on the VS2010 runtime - which isn't on the latest runners
       -

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -59,9 +59,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/aphysci/gravity_base:focal
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.PAT }}
     steps:
       -
         name: clone
@@ -99,9 +96,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/aphysci/gravity_base:jammy
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.PAT }}
     steps:
       -
         name: clone
@@ -139,9 +133,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/aphysci/gravity_base:alma
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.PAT }}
     steps:
       -
         name: clone

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -178,7 +178,7 @@ jobs:
         name: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.7.9'
 
       # The pthreads-win32 build depends on the VS2010 runtime - which isn't on the latest runners
       -

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -173,6 +173,13 @@ jobs:
         with:
           fetch-depth: 0
       
+      # Use a set working python version compatible with the older version of protobuf pulled in
+      - 
+        name: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.7.9'
+
       # The pthreads-win32 build depends on the VS2010 runtime - which isn't on the latest runners
       -
         name: install-VS2010-redistributable

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -13,7 +13,7 @@ jobs:
       image: ghcr.io/aphysci/gravity_base:bionic
       credentials:
         username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       volumes:
         - /node20217:/node20217:rw,rshared
         - /node20217:/__e/node20:ro,rshared

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -12,8 +12,8 @@ jobs:
     container:
       image: ghcr.io/aphysci/gravity_base:bionic
       credentials:
-            username: ${{ github.actor }}
-            password: ${{ secrets.GHCR_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
       volumes:
         - /node20217:/node20217:rw,rshared
         - /node20217:/__e/node20:ro,rshared

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -59,6 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/aphysci/gravity_base:focal
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.PAT }}
     steps:
       -
         name: clone
@@ -96,6 +99,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/aphysci/gravity_base:jammy
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.PAT }}
     steps:
       -
         name: clone
@@ -133,6 +139,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/aphysci/gravity_base:alma
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.PAT }}
     steps:
       -
         name: clone

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -13,7 +13,7 @@ jobs:
       image: ghcr.io/aphysci/gravity_base:bionic
       credentials:
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.PAT }}
       volumes:
         - /node20217:/node20217:rw,rshared
         - /node20217:/__e/node20:ro,rshared

--- a/cmake/GravityExternalUrls.cmake
+++ b/cmake/GravityExternalUrls.cmake
@@ -16,7 +16,7 @@ set(spdlog_url "https://github.com/gabime/spdlog/archive/refs/tags/v1.9.2.zip")
 
 set(boost_url "https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.zip")
 
-set(swigwin_url "http://prdownloads.sourceforge.net/swig/swigwin-4.0.1.zip")
+set(swigwin_url "http://prdownloads.sourceforge.net/swig/swigwin-4.3.1.zip")
 
 set(lexyacc_win_url "https://master.dl.sourceforge.net/project/winflexbison/old_versions/win_flex_bison-2.5.22.zip")
 

--- a/src/api/python/src/python/gravity/__init__.py
+++ b/src/api/python/src/python/gravity/__init__.py
@@ -14,7 +14,11 @@
 # License along with this program;
 # If not, see <http://www.gnu.org/licenses/>.
 #
-
+import os
+if hasattr(os, "add_dll_directory"): # Python >=3.8 on Windows does not search using PATH
+    bin_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "..", "..", "bin")
+    os.add_dll_directory(bin_dir)
+    
 from .gravity import GravityNode, GravitySubscriber, GravityRequestor, GravityServiceProvider, GravityHeartbeatListener, Log, Logger, SpdLog
 from .GravityDataProduct import GravityDataProduct 
 from .GravityLogHandler import GravityLogHandler


### PR DESCRIPTION
Hey @kguilbert - This should bring back the Windows CI/CD.  Please make sure the few Linux pipelines are still ok as well as there is a minor Python code change to allow for Python >= 3.8 on Windows (aa2804f2) (here's an [article](https://medium.com/@python-javascript-php-html-css/resolving-importerror-for-pyd-files-after-upgrading-to-python-3-11-7185411c8fdf) on the issue).  Let me know if there's any issue with merging.